### PR TITLE
Fix setting variable to null when extract files

### DIFF
--- a/file.go
+++ b/file.go
@@ -60,8 +60,8 @@ func extractFiles(input *QueryInput) *UploadMap {
 			for i, uploadVal := range valueTyped {
 				if upload, ok := uploadVal.(Upload); ok {
 					uploadMap.Add(upload, fmt.Sprintf("%s.%d", varName, i))
+					valueTyped[i] = nil
 				}
-				valueTyped[i] = nil
 			}
 			input.Variables[varName] = valueTyped
 		default:

--- a/file_test.go
+++ b/file_test.go
@@ -19,6 +19,7 @@ func TestExtractFiles(t *testing.T) {
 	input := &QueryInput{
 		Variables: map[string]interface{}{
 			"stringParam": "hello world",
+			"listParam":   []interface{}{"one", "two"},
 			"someFile":    upload1,
 			"allFiles": []interface{}{
 				upload2,
@@ -36,6 +37,8 @@ func TestExtractFiles(t *testing.T) {
 	expected.Add(upload3, "allFiles.1")
 
 	assert.Equal(t, expected, actual)
+	assert.Equal(t, "hello world", input.Variables["stringParam"])
+	assert.Equal(t, []interface{}{"one", "two"}, input.Variables["listParam"])
 }
 
 func TestPrepareMultipart(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+sxIXdQ=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/carted/graphql v0.7.6 h1:1DAom3l7Irln/hHlPMBR6w/RirCXjopsCY9WCZc7WUc=
 github.com/carted/graphql v0.7.6/go.mod h1:aIVByVaa4avHzEnahcnHbP48OrkT/+gTtxBT+dPV2R0=
@@ -21,6 +22,7 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=


### PR DESCRIPTION
In my last contribution, I've made a mistake I didn't notice

When extracting files from the request I set the file variable to nil but if the variable is of type "slice" I set it always to nil, even if they are not of type "Upload". Fixing it here and adding the test to cover that case for the future.

@AlecAivazis sorry for the bug I hope we can merge it soon enough.