### PR TITLE
Handle HTTP errors

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -73,7 +73,7 @@ func IntrospectAPI(queryer Queryer) (*ast.Schema, error) {
 	}
 
 	// if we dont have a name on the response
-	if remoteSchema.QueryType.Name == "" {
+	if remoteSchema == nil || remoteSchema.QueryType.Name == "" {
 		return nil, errors.New("Could not find the root query")
 	}
 

--- a/queryer.go
+++ b/queryer.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strconv"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -163,6 +164,11 @@ func (q *NetworkQueryer) sendRequest(acc *http.Request) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	// check for HTTP errors
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return body, errors.New("response was not successful with status code: " + strconv.Itoa(resp.StatusCode))
+	}
 
 	// we're done
 	return body, err


### PR DESCRIPTION
I encountered an error where if a GraphQL introspection query is sent, and the API returns an HTTP error (or anything that is not in the format of a GraphQL error response containing the `errors` field), then the Queryer treats the response as successful. 

This then causes a fatal nil pointer dereference error at https://github.com/nautilus/graphql/blob/master/introspection.go#L76 because `remoteSchema` is `nil`. 

This PR is one possible fix, let me know what you think!