### PR TITLE
Fix invalid escaping of quote in string argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/nautilus/graphql
 
 require (
-	github.com/carted/graphql v0.7.6
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
-	github.com/graphql-go/graphql v0.7.7
+	github.com/graphql-go/graphql v0.7.10-0.20210411022516-8a92e977c10b
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/opentracing/opentracing-go v1.0.2 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -2,15 +2,13 @@ github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+s
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/carted/graphql v0.7.6 h1:1DAom3l7Irln/hHlPMBR6w/RirCXjopsCY9WCZc7WUc=
-github.com/carted/graphql v0.7.6/go.mod h1:aIVByVaa4avHzEnahcnHbP48OrkT/+gTtxBT+dPV2R0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/graph-gophers/dataloader v5.0.0+incompatible h1:R+yjsbrNq1Mo3aPG+Z/EKYrXrXXUNJHOgbRt+U6jOug=
 github.com/graph-gophers/dataloader v5.0.0+incompatible/go.mod h1:jk4jk0c5ZISbKaMe8WsVopGB5/15GvGHMdMdPtwlRp4=
-github.com/graphql-go/graphql v0.7.7 h1:nwEsJGwPq9N6cElOO+NYyoWuELAQZ4GuJks0Rlco5og=
-github.com/graphql-go/graphql v0.7.7/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
+github.com/graphql-go/graphql v0.7.10-0.20210411022516-8a92e977c10b h1:pFOI7cDz2wI+MwaoDqqrhFCXkwvpvkWpYQCXvQVAlfs=
+github.com/graphql-go/graphql v0.7.10-0.20210411022516-8a92e977c10b/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/printer.go
+++ b/printer.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/carted/graphql/language/printer"
 	gAst "github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/printer"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -278,6 +278,33 @@ fragment Foo on User {
 				},
 			},
 		},
+		// json string arguments
+		{
+			`{
+  hello(json: "{\"foo\": \"bar\"}")
+}
+`,
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "json",
+									Value: &ast.Value{
+										Kind: ast.StringValue,
+										Raw:  "{\"foo\": \"bar\"}",
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+			},
+		},
 		// int arguments
 		{
 			`{


### PR DESCRIPTION
The issue in graphql-go/graphql dependency has been just merged: https://github.com/graphql-go/graphql/pull/587

This pull request:
- changes dependency from `carted/graphql` (outdated fork of `graphql-go/graphql`) to `graphql-go/graphql` (latest commit from master)
- adds test case to make sure the input string is escaped correctly 

See the original issue on nautilus/gateway: https://github.com/nautilus/gateway/issues/121