### PR TITLE
fix missing introspectoptions passthrough for introspect remote schema

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -80,7 +80,7 @@ func IntrospectWithContext(ctx context.Context) *IntrospectOptions {
 func IntrospectRemoteSchema(url string, opts ...*IntrospectOptions) (*RemoteSchema, error) {
 
 	// introspect the schema at the designated url
-	schema, err := IntrospectAPI(NewSingleRequestQueryer(url))
+	schema, err := IntrospectAPI(NewSingleRequestQueryer(url), opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introspection options aren't passed through to the IntrospectAPI function when calling IntrospectRemoteSchema. Added the options to the arg list of IntrospectRemoteSchema.