### PR TITLE
fix union sub-types are not added to the union

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -199,15 +199,16 @@ func IntrospectAPI(queryer Queryer, opts ...*IntrospectOptions) (*ast.Schema, er
 					return nil, errors.New("Could not find name of type")
 				}
 
-				// add the type to the union definition
-				if remoteType.Name != storedType.Name {
-					storedType.Types = append(storedType.Types, possibleType.Name)
-				}
-
 				possibleTypeDef, ok := schema.Types[possibleType.Name]
 				if !ok {
 					return nil, errors.New("Could not find type definition for union implementation")
 				}
+
+				// skip the type, if the name equals the current one
+				if possibleType.Name == storedType.Name {
+					continue
+				}
+				storedType.Types = append(storedType.Types, possibleType.Name)
 
 				// add the possible type to the schema
 				schema.AddPossibleType(remoteType.Name, possibleTypeDef)

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -391,6 +391,12 @@ func TestIntrospectQuery_unions(t *testing.T) {
 								Kind: "OBJECT",
 								Name: "Type1",
 							},
+							// ensure the type does not reference itself,
+							// however someone creates a situation where this actually happens (╯°□°)╯︵ ┻━┻
+							{
+								Kind: "UNION",
+								Name: "Maybe",
+							},
 							{
 								Kind: "OBJECT",
 								Name: "Type2",
@@ -420,14 +426,17 @@ func TestIntrospectQuery_unions(t *testing.T) {
 		return
 	}
 
-	// make sure the union matches epectations
+	const expectedTypes = 2
+
+	// make sure the union matches expectations
 	assert.Equal(t, "Maybe", union.Name)
 	assert.Equal(t, ast.Union, union.Kind)
 	assert.Equal(t, "Description", union.Description)
+	assert.Lenf(t, union.Types, expectedTypes, "union.Types should have %d elements", expectedTypes)
 
 	// make sure that the possible types for the Union match expectations
 	possibleTypes := schema.GetPossibleTypes(schema.Types["Maybe"])
-	if len(possibleTypes) != 2 {
+	if len(possibleTypes) != expectedTypes {
 		t.Errorf("Encountered the right number of possible types: %v", len(possibleTypes))
 		return
 	}


### PR DESCRIPTION
This PR is about to fix an issue with union types, I stumbled over. Since v0.0.17 this was broken for me, because the union type appeared to be empty, at least for the introspection. 

I boiled down the issue to be introduced in PR #19. I guess it was a simple typo back then, since the if clause is currently decoupled from the loop.

I modified the test as well, to ensure the `union.Types` slice is actually populated