### PR TITLE
Add introspection retrier option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/opentracing/opentracing-go v1.0.2 // indirect
-	github.com/stretchr/testify v1.4.0
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.0
 	github.com/vektah/gqlparser/v2 v2.0.1
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,13 +16,20 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/vektah/gqlparser/v2 v2.0.1 h1:xgl5abVnsd4hkN9rk65OJID9bfcLSMuTaTcZj777q1o=
 github.com/vektah/gqlparser/v2 v2.0.1/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
@@ -34,3 +41,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -1146,7 +1146,8 @@ func Test_mergeIntrospectOptions(t *testing.T) {
 	}
 }
 
-// mockJSONErrorQueryer unmarshals the internal JSONResult into the receiver. Simulates the real queryer, just a bit.
+// mockJSONErrorQueryer unmarshals the internal JSONResult into the receiver.
+// Like mockJSONQueryer but can return failures for X attempts.
 type mockJSONErrorQueryer struct {
 	FailuresRemaining int
 	FailureErr        error

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -1057,6 +1057,7 @@ func TestIntrospectWithMiddlewares(t *testing.T) {
 }
 
 func Test_mergeIntrospectOptions(t *testing.T) {
+	t.Parallel()
 	client1 := &http.Client{}
 	client2 := &http.Client{}
 	wares1 := []NetworkMiddleware{
@@ -1075,6 +1076,15 @@ func Test_mergeIntrospectOptions(t *testing.T) {
 		{
 			Message:  "nil options",
 			Options:  nil,
+			Expected: IntrospectOptions{},
+		},
+		{
+			Message: "zero value",
+			Options: []*IntrospectOptions{
+				// Zero values. Was previously supported, so don't break back compatibility.
+				{},
+				{},
+			},
 			Expected: IntrospectOptions{},
 		},
 		{
@@ -1122,7 +1132,9 @@ func Test_mergeIntrospectOptions(t *testing.T) {
 		},
 	}
 	for _, row := range table {
+		row := row // enable parallel sub-tests
 		t.Run(row.Message, func(t *testing.T) {
+			t.Parallel()
 			opt := mergeIntrospectOptions(row.Options...)
 			assert.Equal(t, row.Expected.client, opt.client)
 			assert.Equal(t, row.Expected.ctx, opt.ctx)

--- a/retrier.go
+++ b/retrier.go
@@ -1,0 +1,31 @@
+package graphql
+
+// Retrier indicates whether or not to retry and attempt another query.
+type Retrier interface {
+	// ShouldRetry returns true if another attempt should run,
+	// given 'err' from the previous attempt and the total attempt count (starts at 1).
+	//
+	// Consider the 'errors' package to unwrap the error. e.g. errors.As(), errors.Is()
+	ShouldRetry(err error, attempts uint) bool
+}
+
+var _ Retrier = CountRetrier{}
+
+// CountRetrier is a Retrier that stops after a number of attempts.
+type CountRetrier struct {
+	// maxAttempts is the maximum number of attempts allowed before retries should stop.
+	// A value of 0 has undefined behavior.
+	maxAttempts uint
+}
+
+// NewCountRetrier returns a CountRetrier with the given maximum number of retries
+// beyond the first attempt.
+func NewCountRetrier(maxRetries uint) CountRetrier {
+	return CountRetrier{
+		maxAttempts: 1 + maxRetries,
+	}
+}
+
+func (c CountRetrier) ShouldRetry(err error, attempts uint) bool {
+	return attempts < c.maxAttempts
+}

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -1,0 +1,20 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountRetrier(t *testing.T) {
+	t.Parallel()
+	retrier := NewCountRetrier(1)
+	someErr := errors.New("some error")
+
+	assert.Equal(t, CountRetrier{
+		maxAttempts: 2,
+	}, retrier)
+	assert.True(t, retrier.ShouldRetry(someErr, 1))
+	assert.False(t, retrier.ShouldRetry(someErr, 2))
+}


### PR DESCRIPTION
Allows a custom `Retrier` during introspection.
```go
// Retrier indicates whether or not to retry and attempt another query.
type Retrier interface {
	// ShouldRetry returns true if another attempt should run,
	// given 'err' from the previous attempt and the total attempt count (starts at 1).
	//
	// Consider the 'errors' package to unwrap the error. e.g. errors.As(), errors.Is()
	ShouldRetry(err error, attempts uint) bool
}
```

The included `CountRetrier` stops retries after a maximum number of attempts.

Also refactored `IntrospectOptions` a bit to handle more options with less complexity.

Fixes https://github.com/nautilus/graphql/issues/22