### PR TITLE
Add support for Unix sockets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/opentracing/opentracing-go v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
+	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c // indirect
 	github.com/vektah/gqlparser/v2 v2.0.1
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
+github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/vektah/gqlparser/v2 v2.0.1 h1:xgl5abVnsd4hkN9rk65OJID9bfcLSMuTaTcZj777q1o=
 github.com/vektah/gqlparser/v2 v2.0.1/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=

--- a/queryer.go
+++ b/queryer.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/tv42/httpunix"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -151,6 +152,12 @@ func (q *NetworkQueryer) sendRequest(acc *http.Request) ([]byte, error) {
 	// fire the response to the queryer's url
 	if q.Client == nil {
 		q.Client = &http.Client{}
+		// establish unix socket connection if specified
+		if acc.URL.Scheme == "http+unix" {
+			u := &httpunix.Transport{}
+			u.RegisterLocation(acc.URL.Host, acc.URL.Path)
+			q.Client.Transport = u
+		}
 	}
 
 	resp, err := q.Client.Do(acc)


### PR DESCRIPTION
To be able to merge via Unix sockets provided GraphQL schemas with [nautilus/gateway](https://github.com/nautilus/gateway) I extended the `sendRequest` to detect `http+unix` scheme and change the clients transport method accordingly.

Maybe you can add it and update the dependency of [nautilus/gateway](https://github.com/nautilus/gateway) to allow native Unix sockets support. :slightly_smiling_face: 