### PR TITLE
Fix introspect options not ready for use immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.21.x
     - name: Lint
       run: go vet ./...
 
@@ -28,7 +28,10 @@ jobs:
           - 1.15.x
           - 1.16.x
           - 1.17.x
-          - ^1.18  # Latest version of Go
+          - 1.18.x
+          - 1.19.x
+          - 1.20.x
+          - ^1.21  # Latest version of Go
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/introspection.go
+++ b/introspection.go
@@ -53,27 +53,23 @@ func mergeIntrospectOptions(opts ...*IntrospectOptions) *IntrospectOptions {
 // IntrospectWithMiddlewares returns an instance of graphql.IntrospectOptions with given middlewares
 // to be pass to an instance of a graphql.Queryer by the IntrospectOptions.Apply function
 func IntrospectWithMiddlewares(wares ...NetworkMiddleware) *IntrospectOptions {
-	return &IntrospectOptions{
-		mergeFunc: func(opts *IntrospectOptions) {
-			opts.wares = append(opts.wares, wares...)
-		},
-		wares: wares,
-	}
+	return introspectOptsFunc(func(opts *IntrospectOptions) {
+		opts.wares = append(opts.wares, wares...)
+	})
 }
 
 // IntrospectWithHTTPClient returns an instance of graphql.IntrospectOptions with given client
 // to be pass to an instance of a graphql.Queryer by the IntrospectOptions.Apply function
 func IntrospectWithHTTPClient(client *http.Client) *IntrospectOptions {
-	return &IntrospectOptions{
-		mergeFunc: func(opts *IntrospectOptions) {
-			opts.client = client
-		},
-		client: client,
-	}
+	return introspectOptsFunc(func(opts *IntrospectOptions) {
+		opts.client = client
+	})
 }
 
 func introspectOptsFunc(fn func(opts *IntrospectOptions)) *IntrospectOptions {
-	return &IntrospectOptions{mergeFunc: fn}
+	opts := &IntrospectOptions{mergeFunc: fn}
+	opts.mergeFunc(opts)
+	return opts
 }
 
 // IntrospectWithHTTPClient returns an instance of graphql.IntrospectOptions with given context


### PR DESCRIPTION
Fix introspect options not ready for use immediately. This caused a test to fail with Go 1.21.

Uncovered by Go 1.21's behavior change for context.TODO() != context.Background().
Change log: https://go.dev/doc/go1.21#contextpkgcontext
